### PR TITLE
Update WMSLayer.js

### DIFF
--- a/src/WMSLayer.js
+++ b/src/WMSLayer.js
@@ -60,9 +60,10 @@ var WMSLayer = function( options )
 	url += "&srs=";
 	url += options.hasOwnProperty('srs') ? options['srs'] : 'EPSG:4326';
 	url += "&layers=" + options['layers'];
+	url += "&styles=";
 	if ( options.hasOwnProperty('styles') )
 	{
-		url += "&styles=" + options.styles;
+		url += options.styles;
 	}
 	url += "&format=";
 	url += options.hasOwnProperty('format') ? options['format'] : 'image/jpeg';


### PR DESCRIPTION
Fix a bug when WMSLayer does not have "styles" parameter in options ("styles" is a required parameter).
ex : new GlobWeb.WMSLayer({ baseUrl: "http://localhost:8182/wms/wms.cgi", layers: "mola" });
